### PR TITLE
from new Buffer to Buffer.from

### DIFF
--- a/capacitance.js
+++ b/capacitance.js
@@ -13,7 +13,7 @@ var Capacitance = function() {
 Capacitance.prototype = Object.create(Transform.prototype, {
   _write: {
     value: function(data, enc, done) {
-      if(typeof data === 'string') data = new Buffer(data);
+      if (typeof data === 'string') data = Buffer.from(data, enc || 'utf8');
       this.buffers.push(data);
       done();
     }

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -7,7 +7,7 @@ var crypto = require('crypto');
 var expection = [];
 expection.push = function() {
   [].push.apply(this, arguments);
-  if(this.length === 5) {
+  if (this.length === 5) {
     var md5 = crypto.createHash('md5');
     md5.update(this + '');
     var hex = md5.digest('hex');
@@ -18,7 +18,7 @@ expection.push = function() {
 var readable = new Readable();
 readable._read = function() {};
 void function callee(i) {
-  if(i-- > 0) {
+  if (i-- > 0) {
     readable.push(i + '\n');
     setTimeout(callee.bind(null, i), 100);
   } else {


### PR DESCRIPTION
Since `new Buffer` has been deprecated since 6.0.0，use `Buffer.from` instead

[reference](https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding)